### PR TITLE
「地図を表示」ブロックにデフォルト値を用意する。

### DIFF
--- a/extensions/modules/scratch-vm/src/extension-support/geolonia/index.js
+++ b/extensions/modules/scratch-vm/src/extension-support/geolonia/index.js
@@ -76,11 +76,11 @@ class Scratch3GeoloniaBlocks {
                     arguments: {
                         LNG: {
                             type: ArgumentType.NUMBER,
-                            defaultValue: 0,
+                            defaultValue: 139.74,
                         },
                         LAT: {
                             type: ArgumentType.NUMBER,
-                            defaultValue: 0,
+                            defaultValue: 35.65,
                         },
                         ZOOM: {
                             type: ArgumentType.NUMBER,


### PR DESCRIPTION
Scratch のブロックは、スクリプトエリアにドラッグしてそのままクリックしたときに動くのが一般的なので、「地図を表示」のブロックにはデフォルト値（東京の緯度、経度）を設定しておきたいです。